### PR TITLE
HFW1004: Analyzer použití FilteringCollection v dotazu do databáze

### DIFF
--- a/DiagnosticsIdentifiers.cs
+++ b/DiagnosticsIdentifiers.cs
@@ -20,6 +20,10 @@
 		/// </summary>
 		public const string UnitOfWorkAddRangeNestedCollectionId = "HFW1003"; // Category: Usage
 
+		/// <summary>
+		/// FilteringCollection used within an expression tree evaluated by a database query.
+		/// </summary>
+		public const string FilteringCollectionInExpressionTreeId = "HFW1004"; // Category: Usage
 
 	}
 }

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers.Tests/FilteringCollections/FilteringCollectionInExpressionTreeAnalyzerTests.cs
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers.Tests/FilteringCollections/FilteringCollectionInExpressionTreeAnalyzerTests.cs
@@ -46,6 +46,21 @@ namespace TestNamespace
 		}
 	}
 
+	public class MasterBase
+	{
+		public List<Child> ItemsIncludingDeleted { get; } = new List<Child>();
+	}
+
+	public class DerivedMaster : MasterBase
+	{
+		public FilteringCollection<Child> Items { get; }
+
+		public DerivedMaster()
+		{
+			Items = new FilteringCollection<Child>(ItemsIncludingDeleted, child => child.Deleted == null);
+		}
+	}
+
 	public static class QueryableExtensions
 	{
 		public static IQueryable<TEntity> Include<TEntity, TProperty>(this IQueryable<TEntity> source, Expression<Func<TEntity, TProperty>> navigationPropertyPath) => source;
@@ -296,6 +311,134 @@ namespace TestNamespace
 		public int TestMethod(Master master)
 		{
 			return master.Children.Count;
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source);
+	}
+
+	/// <summary>
+	/// Query syntax neobsahuje žádný lambda syntax node - dotaz je na lambdy přeložený až v operation tree.
+	/// </summary>
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_QuerySyntax_ReportsDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IQueryable<Master> masters)
+		{
+			var result = from master in masters
+						 where {|#0:master.Children|}.Any()
+						 select master;
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source, ExpectedDiagnostic("Children", "'ChildrenIncludingDeleted' with an explicit filter"));
+	}
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_QuerySyntaxOverInMemoryCollection_DoesNotReportDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(List<Master> masters)
+		{
+			var result = from master in masters
+						 where master.Children.Any()
+						 select master;
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source);
+	}
+
+	/// <summary>
+	/// Vnořená (quoted) lambda uvnitř outer expression tree - diagnostika se musí hlásit právě jednou.
+	/// </summary>
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_NestedQuotedLambda_ReportsDiagnosticOnce()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IQueryable<Master> masters)
+		{
+			masters.Where(master => masters.Any(other => {|#0:master.Children|}.Any()));
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source, ExpectedDiagnostic("Children", "'ChildrenIncludingDeleted' with an explicit filter"));
+	}
+
+	/// <summary>
+	/// Namapovaný protějšek XIncludingDeleted deklarovaný na bázové entitě - návrh ho musí najít přes dědičnost.
+	/// </summary>
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_IncludingDeletedCounterpartOnBaseType_ReportsDiagnosticWithSuggestion()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IQueryable<DerivedMaster> masters)
+		{
+			masters.Where(master => {|#0:master.Items|}.Any());
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source, ExpectedDiagnostic("Items", "'ItemsIncludingDeleted' with an explicit filter"));
+	}
+
+	/// <summary>
+	/// Lambda předaná data loaderu se přeskakuje celá, bez ohledu na tvar (delší property path by data loader
+	/// odmítl za běhu vlastní - srozumitelnou - výjimkou, analyzer ji neřeší).
+	/// </summary>
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_DataLoaderWithNonWholeBodyLambda_DoesNotReportDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IDataLoader dataLoader, Master master)
+		{
+			dataLoader.Load(master, item => item.Children.First().Master);
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source);
+	}
+
+	/// <summary>
+	/// Params overload data loaderu - lambda je v operation tree zabalená do pole (ArrayCreation/ArrayInitializer).
+	/// </summary>
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_DataLoaderParamsOverload_DoesNotReportDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IDataLoader dataLoader, Master master)
+		{
+			dataLoader.Load(master, item => item.Children, item => item.ChildrenIncludingDeleted);
 		}
 	}
 }";

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers.Tests/FilteringCollections/FilteringCollectionInExpressionTreeAnalyzerTests.cs
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers.Tests/FilteringCollections/FilteringCollectionInExpressionTreeAnalyzerTests.cs
@@ -1,0 +1,331 @@
+﻿using Havit.Data.EntityFrameworkCore.Patterns.Analyzers.FilteringCollections;
+using Havit.Model.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Havit.Data.EntityFrameworkCore.Patterns.Analyzers.Tests.FilteringCollections;
+
+[TestClass]
+public class FilteringCollectionInExpressionTreeAnalyzerTests
+{
+	/// <summary>
+	/// Model, na kterém jsou postaveny všechny testy: <c>Master.Children</c> je FilteringCollection nad namapovanou
+	/// kolekcí <c>Master.ChildrenIncludingDeleted</c>, <c>Master.Others</c> je FilteringCollection bez namapovaného protějšku.
+	/// Součástí je i <c>Include</c> extension metoda se stejnou signaturou, jakou má EF Core (aby testy nemusely
+	/// referencovat EF Core) a metoda přijímající Expression mimo IQueryable (tvar, jaký má např. FluentValidation RuleFor).
+	/// </summary>
+	private const string ModelDeclarations = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Havit.Data.Patterns.DataLoaders;
+using Havit.Model.Collections.Generic;
+
+namespace TestNamespace
+{
+	public class Child
+	{
+		public int Id { get; set; }
+		public DateTime? Deleted { get; set; }
+		public Master Master { get; set; }
+	}
+
+	public class Master
+	{
+		public int Id { get; set; }
+		public List<Child> ChildrenIncludingDeleted { get; } = new List<Child>();
+		public FilteringCollection<Child> Children { get; }
+		public FilteringCollection<Child> Others { get; }
+
+		public Master()
+		{
+			Children = new FilteringCollection<Child>(ChildrenIncludingDeleted, child => child.Deleted == null);
+			Others = new FilteringCollection<Child>(ChildrenIncludingDeleted, child => child.Deleted != null);
+		}
+	}
+
+	public static class QueryableExtensions
+	{
+		public static IQueryable<TEntity> Include<TEntity, TProperty>(this IQueryable<TEntity> source, Expression<Func<TEntity, TProperty>> navigationPropertyPath) => source;
+	}
+
+	public static class Validation
+	{
+		public static void RuleFor<TEntity, TProperty>(Expression<Func<TEntity, TProperty>> propertyPath)
+		{
+		}
+	}
+}
+";
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_WhereWithAnyOnFilteringCollection_ReportsDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IQueryable<Master> masters)
+		{
+			masters.Where(master => {|#0:master.Children|}.Any());
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source, ExpectedDiagnostic("Children", "'ChildrenIncludingDeleted' with an explicit filter"));
+	}
+
+	/// <summary>
+	/// Nejzrádnější případ: ve finální projekci EF Core nehlásí chybu, jen kolekci vůbec nenačte a vrátí prázdno.
+	/// </summary>
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_CountInProjection_ReportsDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IQueryable<Master> masters)
+		{
+			masters.Select(master => new { master.Id, Count = {|#0:master.Children|}.Count });
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source, ExpectedDiagnostic("Children", "'ChildrenIncludingDeleted' with an explicit filter"));
+	}
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_NestedSubqueryInProjection_ReportsDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IQueryable<Master> masters)
+		{
+			masters.Select(master => new { Ids = {|#0:master.Children|}.Select(child => child.Id).ToList() });
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source, ExpectedDiagnostic("Children", "'ChildrenIncludingDeleted' with an explicit filter"));
+	}
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_IncludeOfFilteringCollection_ReportsDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IQueryable<Master> masters)
+		{
+			masters.Include(master => {|#0:master.Children|});
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source, ExpectedDiagnostic("Children", "'ChildrenIncludingDeleted' with an explicit filter"));
+	}
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_ExpressionVariable_ReportsDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public Expression<Func<Master, bool>> GetFilter()
+		{
+			return master => {|#0:master.Children|}.Any();
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source, ExpectedDiagnostic("Children", "'ChildrenIncludingDeleted' with an explicit filter"));
+	}
+
+	/// <summary>
+	/// Kolekce bez namapovaného protějšku <c>XIncludingDeleted</c> - hláška nemá co navrhnout jménem.
+	/// </summary>
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_WithoutIncludingDeletedCounterpart_ReportsDiagnosticWithFallbackSuggestion()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IQueryable<Master> masters)
+		{
+			masters.Where(master => {|#0:master.Others|}.Any());
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source, ExpectedDiagnostic("Others", "the underlying mapped collection with an explicit filter"));
+	}
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_MappedCollection_DoesNotReportDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IQueryable<Master> masters)
+		{
+			masters.Where(master => master.ChildrenIncludingDeleted.Any(child => child.Deleted == null));
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source);
+	}
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_DataLoaderLoad_DoesNotReportDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IDataLoader dataLoader, Master master)
+		{
+			dataLoader.Load(master, item => item.Children);
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source);
+	}
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_DataLoaderLoadAllAsync_DoesNotReportDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public async Task TestMethod(IDataLoader dataLoader, IEnumerable<Master> masters)
+		{
+			await dataLoader.LoadAllAsync(masters, item => item.Children);
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source);
+	}
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_DataLoaderThenLoad_DoesNotReportDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(IDataLoader dataLoader, IEnumerable<Child> children)
+		{
+			dataLoader.LoadAll(children, child => child.Master).ThenLoad(master => master.Children);
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source);
+	}
+
+	/// <summary>
+	/// Cizí API přijímající Expression (např. FluentValidation RuleFor) není dotaz do databáze - hlásit se nemá.
+	/// </summary>
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_ExpressionOutsideQuery_DoesNotReportDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod()
+		{
+			Validation.RuleFor<Master, IEnumerable<Child>>(master => master.Children);
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source);
+	}
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_InMemoryLinq_DoesNotReportDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public void TestMethod(List<Master> masters)
+		{
+			masters.Where(master => master.Children.Any()).ToList();
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source);
+	}
+
+	[TestMethod]
+	public async Task FilteringCollectionInExpressionTreeAnalyzer_DirectAccess_DoesNotReportDiagnostic()
+	{
+		const string source = ModelDeclarations + @"
+namespace TestNamespace
+{
+	public class TestClass
+	{
+		public int TestMethod(Master master)
+		{
+			return master.Children.Count;
+		}
+	}
+}";
+
+		await VerifyAnalyzerAsync(source);
+	}
+
+	private static DiagnosticResult ExpectedDiagnostic(string propertyName, string suggestion)
+	{
+		return new DiagnosticResult(Analyzers.Diagnostics.FilteringCollectionInExpressionTree)
+			.WithLocation(0)
+			.WithArguments(propertyName, suggestion);
+	}
+
+	private static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+	{
+		var test = new CSharpAnalyzerTest<FilteringCollectionInExpressionTreeAnalyzer, DefaultVerifier>
+		{
+			TestState =
+			{
+				Sources = { source },
+				ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+			},
+		};
+
+		test.TestState.AdditionalReferences.Add(typeof(FilteringCollection<>).Assembly);
+		test.TestState.AdditionalReferences.Add(typeof(Data.Patterns.DataLoaders.IDataLoader).Assembly);
+
+		test.ExpectedDiagnostics.AddRange(expected);
+
+		await test.RunAsync();
+	}
+}

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,8 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+HFW1004 | Usage | Warning | Diagnostics

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/Diagnostics.cs
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/Diagnostics.cs
@@ -47,4 +47,23 @@ public static class Diagnostics
 		isEnabledByDefault: true,
 		description: "Detects when IEnumerable<T> is passed to AddForInsert, AddForInsertAsync, AddForUpdate, or AddForDelete methods instead of a single entity."
 	);
+
+	/// <summary>
+	/// Represents a diagnostic descriptor that identifies and reports cases where a member of type
+	/// <c>FilteringCollection&lt;T&gt;</c> is used within an expression tree which is translated to a database query.
+	/// </summary>
+	/// <remarks>
+	/// <c>FilteringCollection&lt;T&gt;</c> is an in-memory wrapper over the underlying (mapped) collection, it is not
+	/// a mapped navigation property. Entity Framework Core is therefore not able to translate it to SQL: the query either
+	/// fails at runtime, or - when the member is used within the final projection - silently returns no data at all.
+	/// </remarks>
+	public static readonly DiagnosticDescriptor FilteringCollectionInExpressionTree = new DiagnosticDescriptor(
+		id: DiagnosticIdentifiers.FilteringCollectionInExpressionTreeId,
+		title: "FilteringCollection used within a database query",
+		messageFormat: "'{0}' is a FilteringCollection which cannot be translated to SQL - the query fails at runtime or silently returns no data. Use {1} instead.",
+		category: "Usage",
+		defaultSeverity: DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: "Detects when a FilteringCollection<T> member is used within an expression tree (LINQ to Entities query). FilteringCollection<T> is an in-memory wrapper which Entity Framework Core cannot translate to SQL."
+	);
 }

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/FilteringCollections/FilteringCollectionConstants.cs
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/FilteringCollections/FilteringCollectionConstants.cs
@@ -1,0 +1,20 @@
+﻿namespace Havit.Data.EntityFrameworkCore.Patterns.Analyzers.FilteringCollections;
+
+internal static class FilteringCollectionConstants
+{
+	internal const string FilteringCollectionTypeName = "FilteringCollection";
+	internal const string FilteringCollectionTypeNamespace = "Havit.Model.Collections.Generic";
+
+	internal const string IncludingDeletedSuffix = "IncludingDeleted";
+
+	internal const string ExpressionTypeName = "Expression";
+	internal const string ExpressionTypeNamespace = "System.Linq.Expressions";
+
+	internal const string QueryableInterfaceName = "IQueryable";
+	internal const string QueryableInterfaceNamespace = "System.Linq";
+
+	internal const string DataLoaderNamespace = "Havit.Data.Patterns.DataLoaders";
+	internal const string DataLoaderInterfaceName = "IDataLoader";
+	internal const string FluentDataLoaderInterfaceName = "IFluentDataLoader";
+	internal const string FluentDataLoaderExtensionsTypeName = "FluentDataLoaderExtensions";
+}

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/FilteringCollections/FilteringCollectionConstants.cs
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/FilteringCollections/FilteringCollectionConstants.cs
@@ -1,20 +1,20 @@
-﻿namespace Havit.Data.EntityFrameworkCore.Patterns.Analyzers.FilteringCollections;
+namespace Havit.Data.EntityFrameworkCore.Patterns.Analyzers.FilteringCollections;
 
 internal static class FilteringCollectionConstants
 {
-	internal const string FilteringCollectionTypeName = "FilteringCollection";
-	internal const string FilteringCollectionTypeNamespace = "Havit.Model.Collections.Generic";
+	internal const string FilteringCollectionMetadataName = "Havit.Model.Collections.Generic.FilteringCollection`1";
 
+	// Konvence pojmenování namapovaného protějšku (X -> XIncludingDeleted) je zduplikovaná vůči runtime substituci
+	// v PropertyLoadSequenceResolverIncludingDeletedFilteringCollectionsSubstitution (Havit.Data.EntityFrameworkCore.Patterns).
+	// Analyzer projekt na Patterns referencovat nemůže. Při změně konvence je potřeba upravit obě místa.
 	internal const string IncludingDeletedSuffix = "IncludingDeleted";
 
-	internal const string ExpressionTypeName = "Expression";
-	internal const string ExpressionTypeNamespace = "System.Linq.Expressions";
+	internal const string ExpressionOfTDelegateMetadataName = "System.Linq.Expressions.Expression`1";
 
-	internal const string QueryableInterfaceName = "IQueryable";
-	internal const string QueryableInterfaceNamespace = "System.Linq";
+	internal const string QueryableMetadataName = "System.Linq.IQueryable";
+	internal const string QueryableOfTMetadataName = "System.Linq.IQueryable`1";
 
-	internal const string DataLoaderNamespace = "Havit.Data.Patterns.DataLoaders";
-	internal const string DataLoaderInterfaceName = "IDataLoader";
-	internal const string FluentDataLoaderInterfaceName = "IFluentDataLoader";
-	internal const string FluentDataLoaderExtensionsTypeName = "FluentDataLoaderExtensions";
+	internal const string DataLoaderMetadataName = "Havit.Data.Patterns.DataLoaders.IDataLoader";
+	internal const string FluentDataLoaderMetadataName = "Havit.Data.Patterns.DataLoaders.IFluentDataLoader`1";
+	internal const string FluentDataLoaderExtensionsMetadataName = "Havit.Data.Patterns.DataLoaders.FluentDataLoaderExtensions";
 }

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/FilteringCollections/FilteringCollectionInExpressionTreeAnalyzer.cs
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/FilteringCollections/FilteringCollectionInExpressionTreeAnalyzer.cs
@@ -1,9 +1,8 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Havit.Data.EntityFrameworkCore.Patterns.Analyzers.FilteringCollections;
 
@@ -15,6 +14,11 @@ namespace Havit.Data.EntityFrameworkCore.Patterns.Analyzers.FilteringCollections
 /// cannot translate it to SQL. Such a query either fails at runtime, or - when the member is used within the final projection -
 /// silently returns no data at all.
 /// <para>
+/// The analysis is operation-based (<see cref="OperationKind.PropertyReference"/>/<see cref="OperationKind.FieldReference"/>),
+/// so it covers both method syntax and query syntax - query clauses are already lowered to expression tree lambdas
+/// in the operation tree.
+/// </para>
+/// <para>
 /// Data loaders (<c>IDataLoader</c>, <c>IFluentDataLoader</c>) are excluded: they do support <c>FilteringCollection&lt;T&gt;</c>
 /// by substituting the <c>XIncludingDeleted</c> collection. Expression trees consumed outside of a database query
 /// (validation rules, mocking setups, ...) have the shape <c>entity =&gt; entity.Collection</c>; that shape is reported only when
@@ -24,8 +28,10 @@ namespace Havit.Data.EntityFrameworkCore.Patterns.Analyzers.FilteringCollections
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class FilteringCollectionInExpressionTreeAnalyzer : DiagnosticAnalyzer
 {
+	private static readonly ImmutableArray<DiagnosticDescriptor> supportedDiagnostics = ImmutableArray.Create(Diagnostics.FilteringCollectionInExpressionTree);
+
 	/// <inheritdoc/>
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Diagnostics.FilteringCollectionInExpressionTree];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => supportedDiagnostics;
 
 	/// <inheritdoc/>
 	public override void Initialize(AnalysisContext context)
@@ -33,151 +39,164 @@ public class FilteringCollectionInExpressionTreeAnalyzer : DiagnosticAnalyzer
 		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 		context.EnableConcurrentExecution();
 
-		context.RegisterSyntaxNodeAction(AnalyzeLambda, SyntaxKind.SimpleLambdaExpression, SyntaxKind.ParenthesizedLambdaExpression);
+		context.RegisterCompilationStartAction(compilationStartContext =>
+		{
+			KnownTypes knownTypes = KnownTypes.TryResolve(compilationStartContext.Compilation);
+			if (knownTypes == null)
+			{
+				// The compilation does not reference FilteringCollection<T> at all - do not register any action.
+				return;
+			}
+
+			compilationStartContext.RegisterOperationAction(
+				operationContext => AnalyzeMemberReference(operationContext, knownTypes),
+				OperationKind.PropertyReference,
+				OperationKind.FieldReference);
+		});
 	}
 
-	private void AnalyzeLambda(SyntaxNodeAnalysisContext context)
+	private static void AnalyzeMemberReference(OperationAnalysisContext context, KnownTypes knownTypes)
 	{
-		var lambda = (LambdaExpressionSyntax)context.Node;
+		var memberReference = (IMemberReferenceOperation)context.Operation;
 
-		if (!IsExpressionTree(lambda, context.SemanticModel, context.CancellationToken))
+		if (!TryGetFilteringCollectionItemType(memberReference.Type, knownTypes, out ITypeSymbol itemType))
 		{
 			return;
 		}
 
-		// Nested expression tree lambdas are already covered by the analysis of the outermost one.
-		if (lambda.Ancestors().OfType<LambdaExpressionSyntax>().Any(ancestor => IsExpressionTree(ancestor, context.SemanticModel, context.CancellationToken)))
+		// The member reference is relevant only when it sits inside a lambda converted to an expression tree.
+		// Each member reference is visited exactly once, so nested (quoted) lambdas need no deduplication;
+		// the outermost expression tree lambda determines the consumer (data loader, IQueryable method, ...).
+		IAnonymousFunctionOperation outermostExpressionTreeLambda = null;
+		for (IOperation current = memberReference.Parent; current != null; current = current.Parent)
 		{
-			return;
-		}
-
-		InvocationExpressionSyntax enclosingInvocation = GetEnclosingInvocation(lambda);
-		if ((enclosingInvocation != null) && IsDataLoaderInvocation(enclosingInvocation, context.SemanticModel, context.CancellationToken))
-		{
-			return;
-		}
-
-		SyntaxNode lambdaBody = (lambda.Body is ExpressionSyntax bodyExpression) ? Unparenthesize(bodyExpression) : null;
-
-		foreach (MemberAccessExpressionSyntax memberAccess in lambda.Body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
-		{
-			ISymbol memberSymbol = context.SemanticModel.GetSymbolInfo(memberAccess, context.CancellationToken).Symbol;
-			ITypeSymbol memberType = GetMemberType(memberSymbol);
-			if ((memberType == null) || !TryGetFilteringCollectionItemType(memberType, out ITypeSymbol itemType))
+			if ((current is IAnonymousFunctionOperation anonymousFunction) && IsConvertedToExpressionTree(anonymousFunction, knownTypes))
 			{
-				continue;
+				outermostExpressionTreeLambda = anonymousFunction;
 			}
-
-			// entity => entity.Collection - the shape used by data loaders, validation rules or mocking setups.
-			// Within a query (Include, Select, ...) it is still an error, anywhere else it is a legitimate usage.
-			if ((memberAccess == lambdaBody)
-				&& ((enclosingInvocation == null) || !IsQueryableInvocation(enclosingInvocation, context.SemanticModel, context.CancellationToken)))
-			{
-				continue;
-			}
-
-			context.ReportDiagnostic(Diagnostic.Create(
-				Diagnostics.FilteringCollectionInExpressionTree,
-				memberAccess.GetLocation(),
-				memberSymbol.Name,
-				GetSuggestion(memberSymbol, itemType)));
 		}
+
+		if (outermostExpressionTreeLambda == null)
+		{
+			return;
+		}
+
+		IInvocationOperation enclosingInvocation = GetEnclosingInvocation(outermostExpressionTreeLambda);
+
+		if ((enclosingInvocation != null) && IsDataLoaderInvocation(enclosingInvocation, knownTypes))
+		{
+			return;
+		}
+
+		// entity => entity.Collection - the shape used by data loaders, validation rules or mocking setups.
+		// Within a query (Include, Select, ...) it is still an error, anywhere else it is a legitimate usage.
+		if (IsWholeLambdaBody(memberReference, outermostExpressionTreeLambda)
+			&& ((enclosingInvocation == null) || !IsQueryableInvocation(enclosingInvocation, knownTypes)))
+		{
+			return;
+		}
+
+		context.ReportDiagnostic(Diagnostic.Create(
+			Diagnostics.FilteringCollectionInExpressionTree,
+			memberReference.Syntax.GetLocation(),
+			memberReference.Member.Name,
+			GetSuggestion(memberReference.Member, itemType)));
 	}
 
 	/// <summary>
-	/// Returns true when the lambda is converted to <c>System.Linq.Expressions.Expression</c> (an expression tree), not to a delegate.
+	/// Returns true when the anonymous function is converted to <c>System.Linq.Expressions.Expression&lt;TDelegate&gt;</c>
+	/// (an expression tree), not to a delegate.
 	/// </summary>
-	private static bool IsExpressionTree(LambdaExpressionSyntax lambda, SemanticModel semanticModel, CancellationToken cancellationToken)
+	private static bool IsConvertedToExpressionTree(IAnonymousFunctionOperation anonymousFunction, KnownTypes knownTypes)
 	{
-		ITypeSymbol convertedType = semanticModel.GetTypeInfo(lambda, cancellationToken).ConvertedType;
-
-		for (ITypeSymbol type = convertedType; type != null; type = type.BaseType)
-		{
-			if ((type.Name == FilteringCollectionConstants.ExpressionTypeName)
-				&& (type.ContainingNamespace?.ToDisplayString() == FilteringCollectionConstants.ExpressionTypeNamespace))
-			{
-				return true;
-			}
-		}
-
-		return false;
+		// An expression tree conversion is an IConversionOperation to Expression<TDelegate> wrapping the anonymous function
+		// (IDelegateCreationOperation is used for conversions to a delegate type only).
+		return (anonymousFunction.Parent is IConversionOperation conversion)
+			&& (conversion.Type is INamedTypeSymbol convertedType)
+			&& SymbolEqualityComparer.Default.Equals(convertedType.OriginalDefinition, knownTypes.ExpressionOfTDelegate);
 	}
 
-	private static ExpressionSyntax Unparenthesize(ExpressionSyntax expression)
+	/// <summary>
+	/// Returns true when the member reference (modulo implicit conversions) forms the whole body of the lambda,
+	/// i.e. the lambda has the shape <c>entity =&gt; entity.Collection</c>.
+	/// </summary>
+	private static bool IsWholeLambdaBody(IMemberReferenceOperation memberReference, IAnonymousFunctionOperation lambda)
 	{
-		while (expression is ParenthesizedExpressionSyntax parenthesized)
+		IOperation current = memberReference;
+		while ((current.Parent is IConversionOperation conversion) && conversion.IsImplicit)
 		{
-			expression = parenthesized.Expression;
+			current = conversion;
 		}
 
-		return expression;
+		return (current.Parent is IReturnOperation returnOperation) && (returnOperation.Parent == lambda.Body);
 	}
 
-	private static InvocationExpressionSyntax GetEnclosingInvocation(LambdaExpressionSyntax lambda)
+	/// <summary>
+	/// Returns the invocation the lambda is passed to as an argument (incl. a <c>params</c> array of expressions), or null.
+	/// </summary>
+	private static IInvocationOperation GetEnclosingInvocation(IAnonymousFunctionOperation lambda)
 	{
-		return ((lambda.Parent is ArgumentSyntax argument) && (argument.Parent is ArgumentListSyntax argumentList))
-			? argumentList.Parent as InvocationExpressionSyntax
+		IOperation current = lambda.Parent;
+		while (current is IDelegateCreationOperation or IConversionOperation or IArrayInitializerOperation or IArrayCreationOperation)
+		{
+			current = current.Parent;
+		}
+
+		return (current is IArgumentOperation argument)
+			? argument.Parent as IInvocationOperation
 			: null;
 	}
 
-	private static bool IsDataLoaderInvocation(InvocationExpressionSyntax invocation, SemanticModel semanticModel, CancellationToken cancellationToken)
+	private static bool IsDataLoaderInvocation(IInvocationOperation invocation, KnownTypes knownTypes)
 	{
-		if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol methodSymbol)
-		{
-			return false;
-		}
-
+		IMethodSymbol methodSymbol = invocation.TargetMethod;
 		INamedTypeSymbol containingType = (methodSymbol.ReducedFrom ?? methodSymbol).ContainingType;
 		if (containingType == null)
 		{
 			return false;
 		}
 
-		return IsDataLoaderType(containingType) || containingType.AllInterfaces.Any(IsDataLoaderType);
+		return IsDataLoaderType(containingType, knownTypes) || containingType.AllInterfaces.Any(interfaceType => IsDataLoaderType(interfaceType, knownTypes));
 	}
 
-	private static bool IsDataLoaderType(INamedTypeSymbol type)
+	private static bool IsDataLoaderType(INamedTypeSymbol type, KnownTypes knownTypes)
 	{
-		if (type.ContainingNamespace?.ToDisplayString() != FilteringCollectionConstants.DataLoaderNamespace)
-		{
-			return false;
-		}
+		INamedTypeSymbol typeDefinition = type.OriginalDefinition;
 
-		return (type.Name == FilteringCollectionConstants.DataLoaderInterfaceName)
-			|| (type.Name == FilteringCollectionConstants.FluentDataLoaderInterfaceName)
-			|| (type.Name == FilteringCollectionConstants.FluentDataLoaderExtensionsTypeName);
+		return SymbolEqualityComparer.Default.Equals(typeDefinition, knownTypes.DataLoader)
+			|| SymbolEqualityComparer.Default.Equals(typeDefinition, knownTypes.FluentDataLoader)
+			|| SymbolEqualityComparer.Default.Equals(typeDefinition, knownTypes.FluentDataLoaderExtensions);
 	}
 
-	private static bool IsQueryableInvocation(InvocationExpressionSyntax invocation, SemanticModel semanticModel, CancellationToken cancellationToken)
+	private static bool IsQueryableInvocation(IInvocationOperation invocation, KnownTypes knownTypes)
 	{
-		if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol methodSymbol)
-		{
-			return false;
-		}
+		IMethodSymbol methodSymbol = invocation.TargetMethod;
 
-		if (IsQueryable(methodSymbol.ReceiverType) || IsQueryable(methodSymbol.ReturnType))
+		if (IsQueryable(methodSymbol.ReceiverType, knownTypes) || IsQueryable(methodSymbol.ReturnType, knownTypes))
 		{
 			return true;
 		}
 
 		// non-reduced form of an extension method: Queryable.Include(source, navigationPropertyPath)
-		return (methodSymbol.Parameters.Length > 0) && IsQueryable(methodSymbol.Parameters[0].Type);
+		return (methodSymbol.Parameters.Length > 0) && IsQueryable(methodSymbol.Parameters[0].Type, knownTypes);
 	}
 
-	private static bool IsQueryable(ITypeSymbol type)
+	private static bool IsQueryable(ITypeSymbol type, KnownTypes knownTypes)
 	{
 		if (type == null)
 		{
 			return false;
 		}
 
-		return IsQueryableInterface(type) || ((type is INamedTypeSymbol namedType) && namedType.AllInterfaces.Any(IsQueryableInterface));
+		return IsQueryableInterface(type, knownTypes) || ((type is INamedTypeSymbol namedType) && namedType.AllInterfaces.Any(interfaceType => IsQueryableInterface(interfaceType, knownTypes)));
 	}
 
-	private static bool IsQueryableInterface(ITypeSymbol type)
+	private static bool IsQueryableInterface(ITypeSymbol type, KnownTypes knownTypes)
 	{
-		return (type.Name == FilteringCollectionConstants.QueryableInterfaceName)
-			&& (type.ContainingNamespace?.ToDisplayString() == FilteringCollectionConstants.QueryableInterfaceNamespace);
+		ITypeSymbol typeDefinition = type.OriginalDefinition;
+
+		return SymbolEqualityComparer.Default.Equals(typeDefinition, knownTypes.Queryable)
+			|| SymbolEqualityComparer.Default.Equals(typeDefinition, knownTypes.QueryableOfT);
 	}
 
 	private static ITypeSymbol GetMemberType(ISymbol symbol)
@@ -190,14 +209,12 @@ public class FilteringCollectionInExpressionTreeAnalyzer : DiagnosticAnalyzer
 		};
 	}
 
-	private static bool TryGetFilteringCollectionItemType(ITypeSymbol type, out ITypeSymbol itemType)
+	private static bool TryGetFilteringCollectionItemType(ITypeSymbol type, KnownTypes knownTypes, out ITypeSymbol itemType)
 	{
 		for (ITypeSymbol currentType = type; currentType != null; currentType = currentType.BaseType)
 		{
-			if ((currentType.Name == FilteringCollectionConstants.FilteringCollectionTypeName)
-				&& (currentType.ContainingNamespace?.ToDisplayString() == FilteringCollectionConstants.FilteringCollectionTypeNamespace)
-				&& (currentType is INamedTypeSymbol namedType)
-				&& (namedType.TypeArguments.Length == 1))
+			if ((currentType is INamedTypeSymbol namedType)
+				&& SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, knownTypes.FilteringCollection))
 			{
 				itemType = namedType.TypeArguments[0];
 				return true;
@@ -235,5 +252,42 @@ public class FilteringCollectionInExpressionTreeAnalyzer : DiagnosticAnalyzer
 		return type.AllInterfaces.Concat([type]).Any(candidateType =>
 			(candidateType.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T)
 			&& SymbolEqualityComparer.Default.Equals(candidateType.TypeArguments.FirstOrDefault(), itemType));
+	}
+
+	/// <summary>
+	/// Symbols of well-known types, resolved once per compilation. Data loader types may be null (the compilation
+	/// does not have to reference Havit.Data.Patterns) - <see cref="SymbolEqualityComparer"/> never matches null.
+	/// </summary>
+	private sealed class KnownTypes
+	{
+		public INamedTypeSymbol FilteringCollection { get; private set; }
+		public INamedTypeSymbol ExpressionOfTDelegate { get; private set; }
+		public INamedTypeSymbol Queryable { get; private set; }
+		public INamedTypeSymbol QueryableOfT { get; private set; }
+		public INamedTypeSymbol DataLoader { get; private set; }
+		public INamedTypeSymbol FluentDataLoader { get; private set; }
+		public INamedTypeSymbol FluentDataLoaderExtensions { get; private set; }
+
+		public static KnownTypes TryResolve(Compilation compilation)
+		{
+			INamedTypeSymbol filteringCollection = compilation.GetTypeByMetadataName(FilteringCollectionConstants.FilteringCollectionMetadataName);
+			INamedTypeSymbol expressionOfTDelegate = compilation.GetTypeByMetadataName(FilteringCollectionConstants.ExpressionOfTDelegateMetadataName);
+
+			if ((filteringCollection == null) || (expressionOfTDelegate == null))
+			{
+				return null;
+			}
+
+			return new KnownTypes
+			{
+				FilteringCollection = filteringCollection,
+				ExpressionOfTDelegate = expressionOfTDelegate,
+				Queryable = compilation.GetTypeByMetadataName(FilteringCollectionConstants.QueryableMetadataName),
+				QueryableOfT = compilation.GetTypeByMetadataName(FilteringCollectionConstants.QueryableOfTMetadataName),
+				DataLoader = compilation.GetTypeByMetadataName(FilteringCollectionConstants.DataLoaderMetadataName),
+				FluentDataLoader = compilation.GetTypeByMetadataName(FilteringCollectionConstants.FluentDataLoaderMetadataName),
+				FluentDataLoaderExtensions = compilation.GetTypeByMetadataName(FilteringCollectionConstants.FluentDataLoaderExtensionsMetadataName),
+			};
+		}
 	}
 }

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/FilteringCollections/FilteringCollectionInExpressionTreeAnalyzer.cs
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/FilteringCollections/FilteringCollectionInExpressionTreeAnalyzer.cs
@@ -1,0 +1,239 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Havit.Data.EntityFrameworkCore.Patterns.Analyzers.FilteringCollections;
+
+/// <summary>
+/// Analyzer that detects usages of <c>FilteringCollection&lt;T&gt;</c> members within expression trees (LINQ to Entities queries).
+/// </summary>
+/// <remarks>
+/// <c>FilteringCollection&lt;T&gt;</c> is an in-memory wrapper over the underlying (mapped) collection, therefore Entity Framework Core
+/// cannot translate it to SQL. Such a query either fails at runtime, or - when the member is used within the final projection -
+/// silently returns no data at all.
+/// <para>
+/// Data loaders (<c>IDataLoader</c>, <c>IFluentDataLoader</c>) are excluded: they do support <c>FilteringCollection&lt;T&gt;</c>
+/// by substituting the <c>XIncludingDeleted</c> collection. Expression trees consumed outside of a database query
+/// (validation rules, mocking setups, ...) have the shape <c>entity =&gt; entity.Collection</c>; that shape is reported only when
+/// the expression is passed to an <c>IQueryable</c> method (e.g. <c>Include</c>).
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class FilteringCollectionInExpressionTreeAnalyzer : DiagnosticAnalyzer
+{
+	/// <inheritdoc/>
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Diagnostics.FilteringCollectionInExpressionTree];
+
+	/// <inheritdoc/>
+	public override void Initialize(AnalysisContext context)
+	{
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+		context.EnableConcurrentExecution();
+
+		context.RegisterSyntaxNodeAction(AnalyzeLambda, SyntaxKind.SimpleLambdaExpression, SyntaxKind.ParenthesizedLambdaExpression);
+	}
+
+	private void AnalyzeLambda(SyntaxNodeAnalysisContext context)
+	{
+		var lambda = (LambdaExpressionSyntax)context.Node;
+
+		if (!IsExpressionTree(lambda, context.SemanticModel, context.CancellationToken))
+		{
+			return;
+		}
+
+		// Nested expression tree lambdas are already covered by the analysis of the outermost one.
+		if (lambda.Ancestors().OfType<LambdaExpressionSyntax>().Any(ancestor => IsExpressionTree(ancestor, context.SemanticModel, context.CancellationToken)))
+		{
+			return;
+		}
+
+		InvocationExpressionSyntax enclosingInvocation = GetEnclosingInvocation(lambda);
+		if ((enclosingInvocation != null) && IsDataLoaderInvocation(enclosingInvocation, context.SemanticModel, context.CancellationToken))
+		{
+			return;
+		}
+
+		SyntaxNode lambdaBody = (lambda.Body is ExpressionSyntax bodyExpression) ? Unparenthesize(bodyExpression) : null;
+
+		foreach (MemberAccessExpressionSyntax memberAccess in lambda.Body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+		{
+			ISymbol memberSymbol = context.SemanticModel.GetSymbolInfo(memberAccess, context.CancellationToken).Symbol;
+			ITypeSymbol memberType = GetMemberType(memberSymbol);
+			if ((memberType == null) || !TryGetFilteringCollectionItemType(memberType, out ITypeSymbol itemType))
+			{
+				continue;
+			}
+
+			// entity => entity.Collection - the shape used by data loaders, validation rules or mocking setups.
+			// Within a query (Include, Select, ...) it is still an error, anywhere else it is a legitimate usage.
+			if ((memberAccess == lambdaBody)
+				&& ((enclosingInvocation == null) || !IsQueryableInvocation(enclosingInvocation, context.SemanticModel, context.CancellationToken)))
+			{
+				continue;
+			}
+
+			context.ReportDiagnostic(Diagnostic.Create(
+				Diagnostics.FilteringCollectionInExpressionTree,
+				memberAccess.GetLocation(),
+				memberSymbol.Name,
+				GetSuggestion(memberSymbol, itemType)));
+		}
+	}
+
+	/// <summary>
+	/// Returns true when the lambda is converted to <c>System.Linq.Expressions.Expression</c> (an expression tree), not to a delegate.
+	/// </summary>
+	private static bool IsExpressionTree(LambdaExpressionSyntax lambda, SemanticModel semanticModel, CancellationToken cancellationToken)
+	{
+		ITypeSymbol convertedType = semanticModel.GetTypeInfo(lambda, cancellationToken).ConvertedType;
+
+		for (ITypeSymbol type = convertedType; type != null; type = type.BaseType)
+		{
+			if ((type.Name == FilteringCollectionConstants.ExpressionTypeName)
+				&& (type.ContainingNamespace?.ToDisplayString() == FilteringCollectionConstants.ExpressionTypeNamespace))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static ExpressionSyntax Unparenthesize(ExpressionSyntax expression)
+	{
+		while (expression is ParenthesizedExpressionSyntax parenthesized)
+		{
+			expression = parenthesized.Expression;
+		}
+
+		return expression;
+	}
+
+	private static InvocationExpressionSyntax GetEnclosingInvocation(LambdaExpressionSyntax lambda)
+	{
+		return ((lambda.Parent is ArgumentSyntax argument) && (argument.Parent is ArgumentListSyntax argumentList))
+			? argumentList.Parent as InvocationExpressionSyntax
+			: null;
+	}
+
+	private static bool IsDataLoaderInvocation(InvocationExpressionSyntax invocation, SemanticModel semanticModel, CancellationToken cancellationToken)
+	{
+		if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol methodSymbol)
+		{
+			return false;
+		}
+
+		INamedTypeSymbol containingType = (methodSymbol.ReducedFrom ?? methodSymbol).ContainingType;
+		if (containingType == null)
+		{
+			return false;
+		}
+
+		return IsDataLoaderType(containingType) || containingType.AllInterfaces.Any(IsDataLoaderType);
+	}
+
+	private static bool IsDataLoaderType(INamedTypeSymbol type)
+	{
+		if (type.ContainingNamespace?.ToDisplayString() != FilteringCollectionConstants.DataLoaderNamespace)
+		{
+			return false;
+		}
+
+		return (type.Name == FilteringCollectionConstants.DataLoaderInterfaceName)
+			|| (type.Name == FilteringCollectionConstants.FluentDataLoaderInterfaceName)
+			|| (type.Name == FilteringCollectionConstants.FluentDataLoaderExtensionsTypeName);
+	}
+
+	private static bool IsQueryableInvocation(InvocationExpressionSyntax invocation, SemanticModel semanticModel, CancellationToken cancellationToken)
+	{
+		if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol methodSymbol)
+		{
+			return false;
+		}
+
+		if (IsQueryable(methodSymbol.ReceiverType) || IsQueryable(methodSymbol.ReturnType))
+		{
+			return true;
+		}
+
+		// non-reduced form of an extension method: Queryable.Include(source, navigationPropertyPath)
+		return (methodSymbol.Parameters.Length > 0) && IsQueryable(methodSymbol.Parameters[0].Type);
+	}
+
+	private static bool IsQueryable(ITypeSymbol type)
+	{
+		if (type == null)
+		{
+			return false;
+		}
+
+		return IsQueryableInterface(type) || ((type is INamedTypeSymbol namedType) && namedType.AllInterfaces.Any(IsQueryableInterface));
+	}
+
+	private static bool IsQueryableInterface(ITypeSymbol type)
+	{
+		return (type.Name == FilteringCollectionConstants.QueryableInterfaceName)
+			&& (type.ContainingNamespace?.ToDisplayString() == FilteringCollectionConstants.QueryableInterfaceNamespace);
+	}
+
+	private static ITypeSymbol GetMemberType(ISymbol symbol)
+	{
+		return symbol switch
+		{
+			IPropertySymbol property => property.Type,
+			IFieldSymbol field => field.Type,
+			_ => null
+		};
+	}
+
+	private static bool TryGetFilteringCollectionItemType(ITypeSymbol type, out ITypeSymbol itemType)
+	{
+		for (ITypeSymbol currentType = type; currentType != null; currentType = currentType.BaseType)
+		{
+			if ((currentType.Name == FilteringCollectionConstants.FilteringCollectionTypeName)
+				&& (currentType.ContainingNamespace?.ToDisplayString() == FilteringCollectionConstants.FilteringCollectionTypeNamespace)
+				&& (currentType is INamedTypeSymbol namedType)
+				&& (namedType.TypeArguments.Length == 1))
+			{
+				itemType = namedType.TypeArguments[0];
+				return true;
+			}
+		}
+
+		itemType = null;
+		return false;
+	}
+
+	/// <summary>
+	/// Returns the name of the mapped counterpart (<c>XIncludingDeleted</c>) when the entity declares one - the very same substitution
+	/// the data loader does. Falls back to a generic wording when there is no such member.
+	/// </summary>
+	private static string GetSuggestion(ISymbol memberSymbol, ITypeSymbol itemType)
+	{
+		string expectedName = memberSymbol.Name + FilteringCollectionConstants.IncludingDeletedSuffix;
+
+		for (INamedTypeSymbol type = memberSymbol.ContainingType; type != null; type = type.BaseType)
+		{
+			foreach (ISymbol candidate in type.GetMembers(expectedName))
+			{
+				if ((GetMemberType(candidate) is INamedTypeSymbol candidateType) && IsEnumerableOf(candidateType, itemType))
+				{
+					return $"'{expectedName}' with an explicit filter";
+				}
+			}
+		}
+
+		return "the underlying mapped collection with an explicit filter";
+	}
+
+	private static bool IsEnumerableOf(INamedTypeSymbol type, ITypeSymbol itemType)
+	{
+		return type.AllInterfaces.Concat([type]).Any(candidateType =>
+			(candidateType.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T)
+			&& SymbolEqualityComparer.Default.Equals(candidateType.TypeArguments.FirstOrDefault(), itemType));
+	}
+}

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/Havit.Data.EntityFrameworkCore.Patterns.Analyzers.csproj
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/Havit.Data.EntityFrameworkCore.Patterns.Analyzers.csproj
@@ -17,7 +17,7 @@
 	<!-- NuGet -->
 	<Import Project="../NuGet.targets" />
 	<PropertyGroup>
-		<PackageVersion>2.10.2</PackageVersion>
+		<PackageVersion>2.11.0</PackageVersion>
 		<!-- https://roslyn-analyzers.readthedocs.io/en/latest/create-nuget-package.html -->
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<NoPackageAnalysis>true</NoPackageAnalysis>

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/Havit.Data.EntityFrameworkCore.Patterns.Analyzers.csproj
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/Havit.Data.EntityFrameworkCore.Patterns.Analyzers.csproj
@@ -17,7 +17,7 @@
 	<!-- NuGet -->
 	<Import Project="../NuGet.targets" />
 	<PropertyGroup>
-		<PackageVersion>2.10.1</PackageVersion>
+		<PackageVersion>2.10.2</PackageVersion>
 		<!-- https://roslyn-analyzers.readthedocs.io/en/latest/create-nuget-package.html -->
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<NoPackageAnalysis>true</NoPackageAnalysis>
@@ -26,14 +26,10 @@
 	</PropertyGroup>
 		
 	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
 	</ItemGroup>
 	
-	<ItemGroup>
-		<ProjectReference Include="..\Havit.Core\Havit.Core.csproj" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<!-- Include analyzers in the package -->
 		<None Include="$(TargetPath)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/README.md
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/README.md
@@ -1,0 +1,21 @@
+﻿HAVIT .NET Framework Extensions - Entity Framework Core Data Patterns - Analyzers
+
+## Účel nuget balíčku
+* Balíček obsahuje Roslyn analyzery, které v compile time hlásí chybná použití API knihovny
+  `Havit.Data.EntityFrameworkCore.Patterns` (resp. `Havit.Data.Patterns`).
+* Jde o vývojovou závislost (`DevelopmentDependency`), do runtime se nic nepřenáší.
+
+## Jak balíček použít
+* Zaregistrujte nuget balíček `Havit.Data.EntityFrameworkCore.Patterns.Analyzers` do projektů,
+  ve kterých se pracuje s `IUnitOfWork`, s modelem a s dotazy do databáze
+  (typicky `Model`, `DataLayer`, `Services`, `Facades`).
+* Jednotlivá pravidla lze standardně konfigurovat v `.editorconfig`
+  (např. `dotnet_diagnostic.HFW1004.severity = error`).
+
+## Pravidla
+
+| ID | Pravidlo |
+| --- | --- |
+| HFW1002 | `IEnumerable<T>` předaný do `IUnitOfWork.AddFor*` metody, která očekává jednu entitu. |
+| HFW1003 | Vnořená kolekce (`IEnumerable<IEnumerable<T>>`) předaná do `IUnitOfWork.AddRangeFor*` metody. |
+| HFW1004 | `FilteringCollection<T>` použitá v expression tree, tedy v dotazu do databáze. Kolekce je in-memory wrapper nad namapovanou kolekcí, EF Core ji nepřeloží do SQL: dotaz buď spadne za běhu, nebo (ve finální projekci) tiše nevrátí žádná data. Řešením je použít namapovanou kolekci `XIncludingDeleted` s explicitním filtrem. Načítání přes `IDataLoader`/`IFluentDataLoader` hlášeno není - data loader `FilteringCollection<T>` podporuje. |

--- a/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/README.md
+++ b/Havit.Data.EntityFrameworkCore.Patterns.Analyzers/README.md
@@ -18,4 +18,4 @@
 | --- | --- |
 | HFW1002 | `IEnumerable<T>` předaný do `IUnitOfWork.AddFor*` metody, která očekává jednu entitu. |
 | HFW1003 | Vnořená kolekce (`IEnumerable<IEnumerable<T>>`) předaná do `IUnitOfWork.AddRangeFor*` metody. |
-| HFW1004 | `FilteringCollection<T>` použitá v expression tree, tedy v dotazu do databáze. Kolekce je in-memory wrapper nad namapovanou kolekcí, EF Core ji nepřeloží do SQL: dotaz buď spadne za běhu, nebo (ve finální projekci) tiše nevrátí žádná data. Řešením je použít namapovanou kolekci `XIncludingDeleted` s explicitním filtrem. Načítání přes `IDataLoader`/`IFluentDataLoader` hlášeno není - data loader `FilteringCollection<T>` podporuje. |
+| HFW1004 | `FilteringCollection<T>` použitá v expression tree, tedy v dotazu do databáze. Kolekce je in-memory wrapper nad namapovanou kolekcí, EF Core ji nepřeloží do SQL: dotaz buď spadne za běhu, nebo (ve finální projekci) tiše nevrátí žádná data. Řešením je použít namapovanou kolekci `XIncludingDeleted` s explicitním filtrem. Pokrývá method syntax i query syntax. Načítání přes `IDataLoader`/`IFluentDataLoader` hlášeno není - data loader `FilteringCollection<T>` podporuje. |

--- a/Havit.Data.EntityFrameworkCore.Patterns/DataLoaders/Internal/PropertyLoadSequenceResolverIncludingDeletedFilteringCollectionsSubstitution.cs
+++ b/Havit.Data.EntityFrameworkCore.Patterns/DataLoaders/Internal/PropertyLoadSequenceResolverIncludingDeletedFilteringCollectionsSubstitution.cs
@@ -19,6 +19,8 @@ public class PropertyLoadSequenceResolverIncludingDeletedFilteringCollectionsSub
 		{
 			// pokud jde o kolekci
 			// a existuje vlastnost s pojmenováním "IncludingDeleted" na konci
+			// (konvence sufixu je zduplikovaná v analyzeru HFW1004 - Havit.Data.EntityFrameworkCore.Patterns.Analyzers,
+			// FilteringCollectionConstants.IncludingDeletedSuffix; při změně konvence je potřeba upravit obě místa)
 			// která obsahuje prvky stejného typu
 			// pak provedeme substituci
 			if (propertyToLoad.IsCollection)


### PR DESCRIPTION
## Proč

`FilteringCollection<T>` je in-memory wrapper nad namapovanou kolekcí (`[NotMapped]`), EF Core ji nepřeloží do SQL. Ověřeno empiricky na modelu 180.EXE (`ExtranetDbContext`, `ToQueryString()`, SqlServer provider):

| tvar dotazu | chování EF Core |
| --- | --- |
| `Where(x => x.UserCards.Any(…))` | `InvalidOperationException` – could not be translated |
| `Where(x => x.UserCards.Count > 0)` | `InvalidOperationException` |
| `OrderBy(x => x.UserCards.Count)` | `InvalidOperationException` |
| `SelectMany(x => x.UserCards)` | `InvalidOperationException` |
| `Include(x => x.UserCards)` | `InvalidOperationException` – „is invalid inside an 'Include' operation" |
| `Select(x => new { Ids = x.UserCards.Select(uc => uc.Id).ToList() })` | `InvalidOperationException` |
| **`Select(x => new { Count = x.UserCards.Count })`** | **projde bez chyby** – SQL na navázanou tabulku vůbec nesáhne, klientské vyhodnocení běží nad nenaplněnou kolekcí a vrátí 0 |
| **`Select(x => new { Cards = x.UserCards.ToList() })`** | **projde bez chyby** – prázdný seznam |

Poslední dva případy jsou hlavní motivace: hlasitý pád si člověk najde při prvním spuštění, nulu v gridu ne. Lazy loading nikde zapnutý není (a properties nejsou `virtual`), takže se nic nedonačte – výsledek závisí jen na tom, co náhodou drží change tracker.

## Co PR přidává

**HFW1004** (`FilteringCollectionInExpressionTreeAnalyzer`, Warning, kategorie Usage) hlásí přístup ke členu typu `FilteringCollection<T>` uvnitř lambdy konvertované na `Expression<…>`.

Aby nepálil na legitimní použití, rozlišuje dva tvary:

- **`entity => entity.Collection`** (celé tělo lambdy) – hlásí jen tehdy, jde-li o metodu nad `IQueryable` (`Include`). Tenhle tvar totiž používá i `IDataLoader.Load*`, `IFluentDataLoader.ThenLoad*`, FluentValidation `RuleFor` nebo Moq `Setup`.
- **`entity.Collection` jako součást větší expression** (`.Any()`, `.Count`, projekce, subquery) – hlásí vždy, tedy i ve `WhereIf`, `OrderByMultiple` nebo v lambdě složené v pomocné metodě vracející `Expression<Func<T, bool>>`.

Navíc je natvrdo vyloučené volání data loaderu (podle typu `IDataLoader` / `IFluentDataLoader` / `FluentDataLoaderExtensions`) – data loader `FilteringCollection` podporuje, `PropertyLoadSequenceResolverIncludingDeletedFilteringCollectionsSubstitution` si sám přepíše property na `XIncludingDeleted`.

Hláška navrhne konkrétní jméno `XIncludingDeleted`, pokud ho entita deklaruje (stejná substituce, jakou dělá data loader), jinak obecný text:

```
warning HFW1004: 'UserCards' is a FilteringCollection which cannot be translated to SQL
- the query fails at runtime or silently returns no data.
Use 'UserCardsIncludingDeleted' with an explicit filter instead.
```

## Druhý commit: úklid balíčku

Balíček `…Patterns.Analyzers` nesl závislosti, které do vývojové závislosti s analyzery nepatří – `ProjectReference` na `Havit.Core` (analyzer z něj nic nepoužívá, jen linkuje `DiagnosticsIdentifiers.cs`) a nepoužívaný `Microsoft.CodeAnalysis.CSharp.Workspaces` bez `PrivateAssets`. Doplněn `Microsoft.CodeAnalysis.Analyzers` (kontrola `AnalyzerReleases.*.md`) a README s popisem HFW1002–HFW1004. `PackageVersion` 2.10.1 → 2.10.2. Výsledný balíček má nulové závislosti a obsahuje jen `analyzers/dotnet/cs/*.dll`.

## Ověření

- 13 nových testů (`CSharpAnalyzerTest`), celý projekt 30/30 zelený. Pokrývají oba hlásící tvary, tichou projekci, `Include`, `IDataLoader.Load` / `LoadAllAsync` / `ThenLoad`, in-memory LINQ (delegát, ne expression), `RuleFor`-like API mimo `IQueryable`, namapovanou kolekci a fallback hlášky bez `XIncludingDeleted` protějšku.
- End-to-end na reálném kódu 180.EXE: analyzer injektovaný do buildu `Model` + `DataLayer` + `Services` + `Facades` → **0 hlášení** (včetně tří míst, kde se `FilteringCollection` legitimně načítá data loaderem). Po umělém záměně `UserCardsIncludingDeleted` → `UserCards` v `UserDetailEmploymentQuery` analyzer zahlásil HFW1004 se správným návrhem.

## Poznámky k review

- Zvolený režim je vědomě široký: hlásí i v expression tree, které nekončí v databázi (např. `RuleFor(x => x.Addresses.Count)`). Mitigace je severita Warning + `.editorconfig`/`#pragma`; allowlist se dá rozšířit podle typu.
- Aby pravidlo doputovalo do 180.EXE, bude potřeba v něm zaregistrovat `PackageReference` na tento balíček – to je samostatná věc, tady není.
